### PR TITLE
Calling as_tibble() as the tests seem to require it

### DIFF
--- a/R/ast2df.R
+++ b/R/ast2df.R
@@ -73,5 +73,6 @@ ast2df <- function(x) {
     flatten_ast() %>%
     lapply(branch2list) %>%
     dplyr::bind_rows() %>%
+    tibble::as_tibble() %>%
     dplyr::mutate_if(is.logical, dplyr::coalesce, FALSE)
 }


### PR DESCRIPTION
From this test: 

```r
test_that('ast2df', {
  expect_identical(
    ast2df(list(blocks = tree)),
    tibble::tibble(
      txt = c('text', 'text'),
      Str = c(TRUE, TRUE),
      Emph = c(TRUE, TRUE),
      Para = c(TRUE, TRUE)
    )
  )
})
```

it looks like the result of `astdf` should be a tibble, so this pr adds a call to `as_tibble()` to enforce it. The next version of `dplyr` which we plan to release this week makes a `data.frame` in that case. 

Alternatively, the test could be: 

```r
test_that('ast2df', {
  expect_equivalent(
    ast2df(list(blocks = tree)),
    tibble::tibble(
      txt = c('text', 'text'),
      Str = c(TRUE, TRUE),
      Emph = c(TRUE, TRUE),
      Para = c(TRUE, TRUE)
    )
  )
})
```