### PR TITLE
perf: let colformat_md call pandoc only once

### DIFF
--- a/R/as-paragraph-md.R
+++ b/R/as-paragraph-md.R
@@ -70,7 +70,8 @@ parse_md <- function(x,
   md_df <- md2df(
     x,
     pandoc_args = c(lua_filters(.sep = .sep), pandoc_args),
-    .from = .from
+    .from = .from,
+    .check = TRUE
   )
 
   id <- pandoc_attrs(md_df$Div, "id")

--- a/R/md2df.R
+++ b/R/md2df.R
@@ -140,18 +140,18 @@ ast2df <- function(x) {
 
 #' Convert Pandoc's Markdown to data frame
 #' @noRd
-md2df <- function(x, .from = "markdown", pandoc_args = NULL) {
+md2df <- function(x, .from = "markdown", pandoc_args = NULL, .check = FALSE) {
   ast <- md2ast(x, .from = .from, pandoc_args = pandoc_args)
 
   ast$blocks <- ast$blocks[
     !vapply(ast$blocks,
-            function(x) identical(c(x$t, x$c[[1]][[1]]), c("Div", "refs")),
+            function(x) identical(c(x$t, x$c[[1L]][[1L]]), c("Div", "refs")),
             NA)
   ]
 
-  # if ((ast$blocks[[1]]$t != "Para") || (length(ast$blocks) > 1)) {
-  #   stop("With Pandoc < 2.2.3, markdown text must be a single paragraph")
-  # }
+  if (.check && any(vapply(ast$blocks, function(x) length(x$c[[2L]]), 0L) > 1L)) {
+    stop("With Pandoc < 2.2.3, markdown text must be a single paragraph")
+  }
 
   ast2df(ast)
 }

--- a/inst/lua/blocks-to-inlines.lua
+++ b/inst/lua/blocks-to-inlines.lua
@@ -4,7 +4,9 @@ function Meta(meta)
     ) or {pandoc.LineBreak(), pandoc.LineBreak()}
 end
 
-function Pandoc(doc)
-  doc.blocks = {pandoc.Para(pandoc.utils.blocks_to_inlines(doc.blocks, sep))}
-  return doc
+function Div(div)
+  div.content = {pandoc.Para(pandoc.utils.blocks_to_inlines(div.content, sep))}
+  return div
 end
+
+return {{Meta = Meta}, {Div = Div}}


### PR DESCRIPTION
Currently, `colformat_md` calls pandoc for every cells.
This may significantly improve the peformance

## benchmark

### before

<img width=50% src=https://user-images.githubusercontent.com/30277794/110554428-21ed6300-817e-11eb-9496-ca75a9d2690c.png>

### after

<img width=50% src=https://user-images.githubusercontent.com/30277794/110553266-17ca6500-817c-11eb-8098-48f840abddf6.png>

### source

````
devtools::load_all()

f <- function(n) {
  x <- as_flextable(data.frame(x = rep('a', n)))
  summary(
    bench::mark(colformat_md(x), min_iterations = 50, filter_gc = FALSE)
  )$median
}

data.frame(n = c(1, 5, 10, 25, 50, 100)) %>%
  dplyr::mutate(time = purrr::map_dbl(n, f)) %>%
  ggplot2::ggplot() +
  ggplot2::aes(n, time) +
  ggplot2::geom_line() +
  ggplot2::geom_point()
````