### PR TITLE
support offsetting citation numbers (closes #40)

### DIFF
--- a/R/as-paragraph-md.R
+++ b/R/as-paragraph-md.R
@@ -105,12 +105,15 @@ as_paragraph_md <- function(x,
                             pandoc_args = NULL,
                             .from = "markdown+autolink_bare_uris",
                             .footnote_options = NULL,
+                            .citation_number = 1L,
                             ...) {
   if (!is.character(auto_color_link) || length(auto_color_link) != 1L) {
     stop("`auto_color_link` must be a string")
   }
 
-  pandoc_args <- c(lua_filters(...), pandoc_args)
+  pandoc_args <- c(lua_filters(...),
+                   pandoc_args_citation_number(.citation_number),
+                   pandoc_args)
   .from <- paste0(.from, paste(md_extensions, collapse=""))
 
   divs <- supported_divs(.from)

--- a/R/colformat.R
+++ b/R/colformat.R
@@ -28,6 +28,7 @@ colformat_md <- function(x,
                          pandoc_args = NULL,
                          .from = "markdown+autolink_bare_uris",
                          .footnote_options = footnote_options(),
+                         .citation_number = 1L,
                          .sep = "\n\n"
 ) {
   .j <- rlang::enexpr(j)
@@ -39,6 +40,7 @@ colformat_md <- function(x,
       x <- colformat_md(x, j = !!.j, part = part,
                         auto_color_link = auto_color_link,
                         .footnote_options = .footnote_options,
+                        .citation_number = .citation_number,
                         .from = .from)
       .footnote_options$value <- list()
     }
@@ -64,6 +66,7 @@ colformat_md <- function(x,
                              md_extensions = md_extensions,
                              pandoc_args = pandoc_args,
                              .footnote_options = .footnote_options,
+                             .citation_number = .citation_number,
                              .sep = .sep
                            ))
 

--- a/R/colformat.R
+++ b/R/colformat.R
@@ -73,7 +73,8 @@ colformat_md <- function(x,
   structure(
     add_footnotes(ft, part, .footnote_options),
     class = c("ftExtra", class(ft)),
-    citations = collect_citations(paste(texts, collapse = "\n\n"))
+    citations = collect_citations(paste(texts, collapse = "\n\n")),
+    vancouver = .citation_number > 1L
   )
 }
 

--- a/R/knit-print.R
+++ b/R/knit-print.R
@@ -21,7 +21,8 @@ knit_print.ftExtra <- function(x,
 
   if (cite == "") return(ft)
 
-  res <- (if (knitr::is_html_output()) {
+  res <- (if (attr(x, "vancouver", exact = TRUE)
+              || isTRUE(options$ftExtra_dummy_cite)) {
     div_cite
   } else {
     yaml_cite
@@ -35,7 +36,7 @@ knit_print.ftExtra <- function(x,
 div_cite <- function(cite, ft, ...) {
   paste0(
     '::: {.ftExtra-dummy-cite style="display: none; visibility: hidden;"}\n\n',
-    cite, "\n\n",
+    "`<w:rPr><w:vanish/></w:rPr>`{=openxml}", cite, "\n\n",
     ':::\n\n',
     ft
   )

--- a/R/knit-print.R
+++ b/R/knit-print.R
@@ -21,7 +21,26 @@ knit_print.ftExtra <- function(x,
 
   if (cite == "") return(ft)
 
-  res <- sprintf('---\n%s: "%s"\n---\n\n%s', key, cite, ft)
+  res <- (if (knitr::is_html_output()) {
+    div_cite
+  } else {
+    yaml_cite
+  })(key = key, cite = cite, ft = ft)
+
   attributes(res) <- attributes(ft)
+
   res
+}
+
+div_cite <- function(cite, ft, ...) {
+  paste0(
+    '::: {.ftExtra-dummy-cite style="display: none; visibility: hidden;"}\n\n',
+    cite, "\n\n",
+    ':::\n\n',
+    ft
+  )
+}
+
+yaml_cite <- function(key, cite, ft, ...) {
+  sprintf('---\n%s: "%s"\n---\n\n%s', key, cite, ft)
 }

--- a/R/md2ast.R
+++ b/R/md2ast.R
@@ -21,7 +21,7 @@ md2ast <- function(x,
     from = .from,
     output = tf,
     citeproc = !is.null(yaml$bibliography) || any(grepl("^--bibliography", pandoc_args)),
-    options = pandoc_args,
+    options = c(sprintf("--bibliography=%s", yaml$bibliography), pandoc_args),
     wd = getwd()
   )
 

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -51,6 +51,8 @@ temp_yaml_cite <- function(n) {
 pandoc_args_citation_number <- function(n = 1L) {
   if (n <= 1L) return(character(0))
 
+  n <- n - 1L
+
   return(c(paste0("--bibliography=", temp_bib(n)),
            paste0("--metadata-file=", temp_yaml_cite(n))))
 }

--- a/R/pandoc.R
+++ b/R/pandoc.R
@@ -26,3 +26,31 @@ lua_filters <- function(.sep = "\n\n") {
     }
   )
 }
+
+temp_bib <- function(n) {
+  temp_file <- tempfile(fileext = ".bib")
+  xfun::write_utf8(
+    paste0("@book{ftExtra-dummy-entry-",
+           seq(n),
+           ", author = {ftExtra}, title = {ftExtra}, publisher = {ftExtra}}"),
+    temp_file
+  )
+  return(temp_file)
+}
+
+temp_yaml_cite <- function(n) {
+  temp_file <- tempfile(fileext = ".yml")
+  xfun::write_utf8(
+    sprintf('ftExtra-dummy-cite: "%s"',
+            paste(paste0("@ftExtra-dummy-entry-", seq(n)), collapse = " ")),
+    temp_file
+  )
+  return(temp_file)
+}
+
+pandoc_args_citation_number <- function(n = 1L) {
+  if (n <= 1L) return(character(0))
+
+  return(c(paste0("--bibliography=", temp_bib(n)),
+           paste0("--metadata-file=", temp_yaml_cite(n))))
+}


### PR DESCRIPTION
Current implementation adds `.citation_number` to `colformat_md` so that user can control the numbering.

reprex

````
---
output:
  html_document: default
  word_document: default
bibliography: example.bib
csl: example.csl
---

```{cat, include=FALSE, engine.opts=list(file = "example.bib")}
@Book{example1, author = {author1}, title = {title}, year = {2021},}

@Book{example2, author = {author2}, title = {title}, year = {2021},}

@Book{example3, author = {author3}, title = {title}, year = {2021},}
```

```{r}
download.file(
  "https://raw.githubusercontent.com/citation-style-language/styles/master/vancouver.csl",
  "example.csl"
)
```


`@example1` becomes @example1

```{r}
ftExtra::colformat_md(
  flextable::flextable(
    data.frame(x = c("`@example2` becomes @example2"))
  ),
  .citation_number = 2L
)
```

`@example3` becomes @example3
````
