### PR TITLE
Remove broken `names_ptypes` usage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# ftExtra 0.3.0.9999
+
+* Support tidyr 1.2.0 (thanks, @DavisVaughan, #66)
+
 # ftExtra 0.3.0
 
 ## New features

--- a/R/header-transform.R
+++ b/R/header-transform.R
@@ -7,7 +7,6 @@ fill_header <- function(x, fill = TRUE) {
       tidyselect::starts_with("level"),
       names_to = "var",
       names_prefix = "level",
-      names_ptypes = integer(),
       values_to = "val"
     ) %>%
     tidyr::fill("val") %>%


### PR DESCRIPTION
Hi @atusy,

We are planning a release of tidyr for early to mid January, and your package was flagged in our revdeps.

If you install the dev version of tidyr, you can reproduce the issue with:

``` r
x <- data.frame(original = "foo", level1 = "foo", level2 = NA_character_)
ftExtra:::fill_header(x)
#> Error: Can't convert <character> to <integer>.
```

It looks like in `fill_header()` you are supplying `names_ptypes = integer()` in `pivot_longer()`. This actually should never have worked, you are supposed to supply a list of named ptypes, like `list(var = integer())`. Regardless, this wouldn't actually work because you can't cast a character column to integer using `names_ptypes`. If you want that, you need `names_transform = list(var = as.integer)`.

We have just added the ability to do `names_ptypes = integer()` into the dev version of tidyr, which is why you now see the cast error.

Since you immediately pivot-wider right after this, I don't think you actually need to cast to integer. Just leave them as character names because they will end up as column names in the end.

We would greatly appreciate if you could merge this PR and plan for a CRAN release around early January! You should be able to go ahead and send to CRAN, as this doesn't rely on dev tidyr in any way. Thank you!
