### PR TITLE
Fix `as_flextable()` for multiple grouping data.frame

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ License: MIT + file LICENSE
 URL: https://ftextra.atusy.net, https://github.com/atusy/ftExtra
 BugReports: https://github.com/atusy/ftExtra/issues
 Imports:
-    dplyr,
+    dplyr (>= 1.0.0),
     jsonlite,
     flextable (>= 0.6.4),
     tidyr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ftExtra
 Title: Extensions for 'Flextable'
-Version: 0.4.0
+Version: 0.4.0.9999
 Date: 2022-04-20
 Authors@R: 
   c(person(given = "Atsushi",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,11 @@ Authors@R:
     person(given = "Romain",
            family = "François",
            role = "ctb",
-           comment = c(ORCID = "0000-0002-2444-4226")))
+           comment = c(ORCID = "0000-0002-2444-4226")),
+    person(given = "Tatsuya",
+           family = "Shima",
+           email = "ts1s1andn@gmail.com",
+           role = "ctb"))
 Maintainer: Atsushi Yasumoto <atusy.rpkg@gmail.com>
 Description: Build display tables easily by extending the functionality of the
     'flextable' package. Features include spanning header, grouping rows,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# ftExtra 0.4.0.9999
+
+* Fix `as_flextable.grouped_df` which broke second and subsequent group variables. Also, this function gains `groups_arrange` argument. The default value is `NULL` which implies `FALSE` for the backward-compatibility. In the next version, `NULL` remains the default but becomes deprecated. Then, `TRUE` becomes the default in the subsequent release (thanks, @eitsupi, #76).
+
 # ftExtra 0.4.0
 
 * `as_paragraph_md` supports empty string, `""`, as an input (#68).

--- a/R/as-flextable.R
+++ b/R/as-flextable.R
@@ -52,7 +52,7 @@ as_flextable.grouped_df <- function(
         dplyr::ungroup() %>%
         dplyr::select(if (groups_pos == "left") g, tidyselect::everything()) %>%
         as_flextable.data.frame(...) %>%
-        flextable::merge_v(g[1L], g) %>%
+        flextable::merge_v(g) %>%
         flextable::theme_vanilla() %>%
         flextable::fix_border_issues()
     )

--- a/R/as-flextable.R
+++ b/R/as-flextable.R
@@ -10,6 +10,10 @@ flextable::as_flextable
 #' @param groups_pos
 #'   When `groups_to = "merged"`, grouping columns are reordered according to
 #'   `group_pos`. Choices are `left` (default) or `asis`.
+#' @param arrange_groups
+#'   When `TRUE`, grouping columns are sorted by [dplyr::arrange()].
+#'   If you want to sort by yourself,
+#'   set `FALSE` and give `x` the grouped data.frame after sorting.
 #'
 #' @examples
 #'
@@ -27,6 +31,7 @@ as_flextable.grouped_df <- function(
                                     x,
                                     groups_to = c("titles", "merged", "asis"),
                                     groups_pos = c("left", "asis"),
+                                    arrange_groups = FALSE,
                                     ...) {
   groups_to <- match.arg(groups_to)
   groups_pos <- match.arg(groups_pos)
@@ -36,6 +41,8 @@ as_flextable.grouped_df <- function(
   }
 
   g <- group_of(x)
+
+  if (arrange_groups) x <- dplyr::arrange(x, dplyr::across({{ g }}))
 
   if (groups_to == "titles") {
     return(

--- a/R/as-flextable.R
+++ b/R/as-flextable.R
@@ -6,7 +6,8 @@ flextable::as_flextable
 #' @name as_flextable_methods
 #' @inherit flextable::as_flextable
 #' @param groups_to
-#'   One of `titles`, `merged`, or `asis`. See examples for the result.
+#'   One of `titles`, `merged`, or `asis`.
+#'   See examples and `vignette("group-rows")` for the result.
 #' @param groups_pos
 #'   When `groups_to = "merged"`, grouping columns are reordered according to
 #'   `group_pos`. Choices are `left` (default) or `asis`.

--- a/R/as-flextable.R
+++ b/R/as-flextable.R
@@ -11,10 +11,11 @@ flextable::as_flextable
 #' @param groups_pos
 #'   When `groups_to = "merged"`, grouping columns are reordered according to
 #'   `group_pos`. Choices are `left` (default) or `asis`.
-#' @param arrange_groups
-#'   When `TRUE`, grouping columns are sorted by [dplyr::arrange()].
-#'   If you want to sort by yourself,
-#'   set `FALSE` and give `x` the grouped data.frame after sorting.
+#' @param groups_arrange
+#'   `TRUE` automatically arranges grouping columns by [dplyr::arrange()].
+#'   Specify `FALSE` to keep the arrangement of the input data frame.
+#'   The default value is `NULL` which implies `FALSE` to keep the backward
+#'   compatibility, but will be `TRUE` in the future.
 #'
 #' @examples
 #'
@@ -32,7 +33,7 @@ as_flextable.grouped_df <- function(
                                     x,
                                     groups_to = c("titles", "merged", "asis"),
                                     groups_pos = c("left", "asis"),
-                                    arrange_groups = FALSE,
+                                    groups_arrange = NULL,
                                     ...) {
   groups_to <- match.arg(groups_to)
   groups_pos <- match.arg(groups_pos)
@@ -43,7 +44,7 @@ as_flextable.grouped_df <- function(
 
   g <- group_of(x)
 
-  if (arrange_groups) x <- dplyr::arrange(x, dplyr::across({{ g }}))
+  if (isTRUE(groups_arrange)) x <- dplyr::arrange(x, dplyr::across({{ g }}))
 
   if (groups_to == "titles") {
     return(

--- a/man/as_flextable_methods.Rd
+++ b/man/as_flextable_methods.Rd
@@ -19,7 +19,8 @@
 \arguments{
 \item{x}{object to be transformed as flextable}
 
-\item{groups_to}{One of \code{titles}, \code{merged}, or \code{asis}. See examples for the result.}
+\item{groups_to}{One of \code{titles}, \code{merged}, or \code{asis}.
+See examples and \code{vignette("group-rows")} for the result.}
 
 \item{groups_pos}{When \code{groups_to = "merged"}, grouping columns are reordered according to
 \code{group_pos}. Choices are \code{left} (default) or \code{asis}.}

--- a/man/as_flextable_methods.Rd
+++ b/man/as_flextable_methods.Rd
@@ -10,7 +10,7 @@
   x,
   groups_to = c("titles", "merged", "asis"),
   groups_pos = c("left", "asis"),
-  arrange_groups = FALSE,
+  groups_arrange = NULL,
   ...
 )
 
@@ -25,9 +25,10 @@ See examples and \code{vignette("group-rows")} for the result.}
 \item{groups_pos}{When \code{groups_to = "merged"}, grouping columns are reordered according to
 \code{group_pos}. Choices are \code{left} (default) or \code{asis}.}
 
-\item{arrange_groups}{When \code{TRUE}, grouping columns are sorted by \code{\link[dplyr:arrange]{dplyr::arrange()}}.
-If you want to sort by yourself,
-set \code{FALSE} and give \code{x} the grouped data.frame after sorting.}
+\item{groups_arrange}{\code{TRUE} automatically arranges grouping columns by \code{\link[dplyr:arrange]{dplyr::arrange()}}.
+Specify \code{FALSE} to keep the arrangement of the input data frame.
+The default value is \code{NULL} which implies \code{FALSE} to keep the backward
+compatibility, but will be \code{TRUE} in the future.}
 
 \item{...}{arguments for custom methods}
 

--- a/man/as_flextable_methods.Rd
+++ b/man/as_flextable_methods.Rd
@@ -10,6 +10,7 @@
   x,
   groups_to = c("titles", "merged", "asis"),
   groups_pos = c("left", "asis"),
+  arrange_groups = FALSE,
   ...
 )
 
@@ -22,6 +23,10 @@
 
 \item{groups_pos}{When \code{groups_to = "merged"}, grouping columns are reordered according to
 \code{group_pos}. Choices are \code{left} (default) or \code{asis}.}
+
+\item{arrange_groups}{When \code{TRUE}, grouping columns are sorted by \code{\link[dplyr:arrange]{dplyr::arrange()}}.
+If you want to sort by yourself,
+set \code{FALSE} and give \code{x} the grouped data.frame after sorting.}
 
 \item{...}{arguments for custom methods}
 

--- a/tests/testthat/test-as-flextable.R
+++ b/tests/testthat/test-as-flextable.R
@@ -62,7 +62,7 @@ test_that("as_flextable.grouped_df multi groups", {
   )
 
   expect_identical(
-    as_flextable(d, groups_to = "merged", arrange_groups = TRUE),
+    as_flextable(d, groups_to = "merged", groups_arrange = TRUE),
     x %>%
       dplyr::relocate(am, cyl, mpg) %>%
       dplyr::arrange(am, cyl, mpg) %>%

--- a/tests/testthat/test-as-flextable.R
+++ b/tests/testthat/test-as-flextable.R
@@ -41,3 +41,51 @@ test_that("as.flextable.grouped_df", {
     flextable::flextable(x)
   )
 })
+
+test_that("as_flextable.grouped_df multi groups", {
+  x <- mtcars %>%
+    tibble::as_tibble(rownames = "model") %>%
+    dplyr::select(model, cyl, mpg, disp, am)
+  d <- x %>%
+    dplyr::group_by(am, cyl, mpg)
+  f <- flextable::as_grouped_data(x, groups = c("am", "cyl", "mpg"))
+
+  expect_identical(as_flextable(d), as_flextable(f))
+
+  expect_identical(
+    as_flextable(d, groups_to = "merged"),
+    x %>%
+      dplyr::relocate(am, cyl, mpg) %>%
+      flextable::flextable() %>%
+      flextable::merge_v(c("am", "cyl", "mpg")) %>%
+      flextable::theme_vanilla()
+  )
+
+  expect_identical(
+    as_flextable(d, groups_to = "merged", groups_pos = "asis"),
+    x %>%
+      flextable::flextable() %>%
+      flextable::merge_v(c("am", "cyl", "mpg")) %>%
+      flextable::theme_vanilla()
+  )
+
+  expect_identical(
+    as_flextable(
+      d,
+      groups_to = "merged",
+      col_keys = with_blanks(tidyselect::starts_with("m"))
+    ),
+    x %>%
+      dplyr::relocate(am, cyl, mpg) %>%
+      flextable::flextable(
+        col_keys = c("am", "cyl", "mpg", "..after1", "model", "..after2", "disp")
+      ) %>%
+      flextable::merge_v(c("am", "cyl", "mpg")) %>%
+      flextable::theme_vanilla()
+  )
+
+  expect_identical(
+    as_flextable(d, groups_to = "asis"),
+    flextable::flextable(x)
+  )
+})

--- a/tests/testthat/test-as-flextable.R
+++ b/tests/testthat/test-as-flextable.R
@@ -62,6 +62,16 @@ test_that("as_flextable.grouped_df multi groups", {
   )
 
   expect_identical(
+    as_flextable(d, groups_to = "merged", arrange_groups = TRUE),
+    x %>%
+      dplyr::relocate(am, cyl, mpg) %>%
+      dplyr::arrange(am, cyl, mpg) %>%
+      flextable::flextable() %>%
+      flextable::merge_v(c("am", "cyl", "mpg")) %>%
+      flextable::theme_vanilla()
+  )
+
+  expect_identical(
     as_flextable(d, groups_to = "merged", groups_pos = "asis"),
     x %>%
       flextable::flextable() %>%

--- a/vignettes/group-rows.Rmd
+++ b/vignettes/group-rows.Rmd
@@ -76,12 +76,12 @@ grouped_iris %>%
 
 ```{r}
 grouped_mtcars %>%
-  as_flextable(groups_to = "merged", arrange_groups = TRUE)
+  as_flextable(groups_to = "merged", groups_arrange = TRUE)
 ```
 
 ```{r}
 grouped_mtcars %>%
-  as_flextable(groups_to = "merged", arrange_groups = FALSE)
+  as_flextable(groups_to = "merged", groups_arrange = FALSE)
 ```
 
 ## Position of grouping variables

--- a/vignettes/group-rows.Rmd
+++ b/vignettes/group-rows.Rmd
@@ -76,14 +76,12 @@ grouped_iris %>%
 
 ```{r}
 grouped_mtcars %>%
-  as_flextable(groups_to = "merged", arrange_groups = TRUE) %>%
-  flextable::theme_vanilla()
+  as_flextable(groups_to = "merged", arrange_groups = TRUE)
 ```
 
 ```{r}
 grouped_mtcars %>%
-  as_flextable(groups_to = "merged", arrange_groups = FALSE) %>%
-  flextable::theme_vanilla()
+  as_flextable(groups_to = "merged", arrange_groups = FALSE)
 ```
 
 ## Position of grouping variables

--- a/vignettes/group-rows.Rmd
+++ b/vignettes/group-rows.Rmd
@@ -76,7 +76,13 @@ grouped_iris %>%
 
 ```{r}
 grouped_mtcars %>%
-  as_flextable(groups_to = "merged") %>%
+  as_flextable(groups_to = "merged", arrange_groups = TRUE) %>%
+  flextable::theme_vanilla()
+```
+
+```{r}
+grouped_mtcars %>%
+  as_flextable(groups_to = "merged", arrange_groups = FALSE) %>%
   flextable::theme_vanilla()
 ```
 


### PR DESCRIPTION
When multiple grouping variables are specified, the second and subsequent grouping variables do not seem to be handled correctly.

```r
mtcars |>
  dplyr::mutate(model = rownames(mtcars)) |>
  head() |>
  dplyr::select(model, cyl, mpg, disp, am) |>
  dplyr::group_by(am, cyl) |>
  as_flextable(groups_to = "merged")
```

Release version
![image](https://user-images.githubusercontent.com/50911393/165085383-b16c86ac-e89e-4bf2-9f08-6480da3c53bb.png)

This PR
![image](https://user-images.githubusercontent.com/50911393/165085215-4cf09202-72e6-44a5-a342-50e07c8d088c.png)
