### PR TITLE
fix(colformat_md): respect `md_extensions` when `part = "all"`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ftExtra
 Title: Extensions for 'Flextable'
-Version: 0.6.4
+Version: 0.6.4.9999
 Date: 2024-05-11
 Authors@R: 
   c(person(given = "Atsushi",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# ftExtra 0.6.4.9999
+
+* Fix `colformat_md` to apply `md_extensions` when `part = "all"` (#110, thanks @astrochemx)
+
 # ftExtra 0.6.4
 
 * Fix broken markdown rendering from a change in **flextable** 0.9.5 (#103)

--- a/R/colformat.R
+++ b/R/colformat.R
@@ -41,6 +41,7 @@ colformat_md <- function(x,
       x <- colformat_md(x,
         j = !!.j, part = part,
         auto_color_link = auto_color_link,
+        md_extensions = md_extensions,
         pandoc_args = pandoc_args, metadata = metadata,
         replace_na = replace_na, .from = .from,
         .footnote_options = .footnote_options, .sep = .sep


### PR DESCRIPTION
Hi @atusy !
Thank you for a very helpful package!

This PR fixes an issue in the `colformat_md` function where the `md_extensions` argument was ignored when the function was called with `part = "all"`.

Looking forward to your review and feedback. Thanks!